### PR TITLE
화면의 크기를 조절을 하더라도 컴포넌트가 곂치거나 안보이지않게 수정

### DIFF
--- a/src/components/Editor/Editors.tsx
+++ b/src/components/Editor/Editors.tsx
@@ -24,9 +24,12 @@ function TabPanel(props: TabPanelProps) {
       id={`simple-tabpanel-${index}`}
       aria-labelledby={`simple-tab-${index}`}
       {...other}
+      style={{ height: "100%" }}
     >
       {EditorContentsStore.veiwIndex === index && (
-        <Box sx={{ p: 3 }}>{children}</Box>
+        <Box sx={{ p: 3 }} style={{ height: "100%" }}>
+          {children}
+        </Box>
       )}
     </div>
   );
@@ -59,7 +62,7 @@ export const Editors = () => {
   };
 
   return (
-    <Box sx={{ bgcolor: "background.paper" }}>
+    <Box sx={{ bgcolor: "background.paper" }} style={{ height: "100%" }}>
       <Tabs
         value={EditorContentsStore.veiwIndex}
         onChange={handleChange}

--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -8,6 +8,7 @@ import { useObserver } from "mobx-react";
 import EditorContentsStore from "../../stores/editorContentsStore";
 import WorkspaceStore from "../../stores/workspaceStore";
 import { setAlert } from "../../utils/alert-utiles";
+import { flexbox } from "@mui/system";
 // import parseAndGetASTRoot from "../../language-service/parser";
 
 // function validate(model) {
@@ -76,6 +77,7 @@ const Editor: React.FC<IEditorProps> = (props: IEditorProps) => {
           EditorContentsStore.contents[EditorContentsStore.veiwIndex].content,
         // model,
       });
+      divNode.style.height = "100%";
       // validate(model);
       // model.onDidChangeContent(() => {
       //   // validate(model);
@@ -146,27 +148,27 @@ const Editor: React.FC<IEditorProps> = (props: IEditorProps) => {
   };
 
   return (
-    <div style={{ height: 750 }}>
-      <TextField
-        autoFocus
-        margin="dense"
-        id="name"
-        label="Commit Message"
-        type="text"
-        fullWidth
-        variant="standard"
-        onChange={onReferenceNameChange}
-      />
-      <Button variant="outlined" onClick={onCommitClick}>
-        Commit
-        <AddIcon />
-      </Button>
+    <div style={{ height: "80%", display: "flex", flexDirection: "column" }}>
       {useObserver(() => (
         <>
+          <div ref={assignRef} className="editor-container"></div>
           <div className="title">
             {EditorContentsStore.contents[EditorContentsStore.veiwIndex].path}
           </div>
-          <div ref={assignRef} className="editor-container"></div>
+          <TextField
+            autoFocus
+            margin="dense"
+            id="name"
+            label="Commit Message"
+            type="text"
+            fullWidth
+            variant="standard"
+            onChange={onReferenceNameChange}
+          />
+          <Button variant="outlined" onClick={onCommitClick}>
+            Commit
+            <AddIcon />
+          </Button>
         </>
       ))}
       {/* <div>Content Change Position</div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,10 +42,10 @@ const App = () => {
 
 const Main = () => {
   return (
-    <div>
+    <div style={{ height: "100%" }}>
       <LNB />
-      <div className="editor-area">
-        {/* <div className="title">Java Editor</div> */}        
+      <div className="editor-area" style={{ height: "100%" }}>
+        {/* <div className="title">Java Editor</div> */}
         <Editors />
       </div>
     </div>

--- a/src/style.css
+++ b/src/style.css
@@ -10,9 +10,13 @@ body,
 .title {
   height: 50px;
 }
-
+@media only screen and (max-height: 600px) {
+  .editor-container {
+    height: 50%;
+  }
+}
 .editor-container {
-  height: calc(100% - 50px);
+  height: 100%;
   overflow: hidden;
   width: auto;
 }
@@ -21,7 +25,7 @@ body,
   height: 100%;
   position: fixed;
   right: 0;
-  width: 85%;
+  width: calc(100% - 270px);
 }
 
 .sidebar {
@@ -38,7 +42,11 @@ body,
 
 .alert {
   position: absolute;
-  z-Index: 4800;
+  z-index: 4800;
   padding: 20px;
   right: 10px;
+}
+
+.monaco-editor {
+  height: 100% !important;
 }


### PR DESCRIPTION
화면의 크기를 조절을 하더라도 컴포넌트가 곂치거나 안보이지않게 수정
- 화면의 가로를 줄였을때 탭의 위치
(전)
<img width="977" alt="스크린샷 2023-02-07 오전 10 54 57" src="https://user-images.githubusercontent.com/82989054/217134067-ce1c2c15-50cd-41cd-a541-0094e6172049.png">
(후)
<img width="958" alt="스크린샷 2023-02-07 오전 10 55 43" src="https://user-images.githubusercontent.com/82989054/217134047-a4cb0606-9f98-4677-a54c-a71878ccc4ab.png">
- 화면의 높이를 줄였을때 커밋의 위치

(전 아래부분이 짤려서 안보임)
<img width="864" alt="스크린샷 2023-02-07 오전 9 09 42" src="https://user-images.githubusercontent.com/82989054/217134882-ddd69425-b5a8-4bb9-979e-2df527c5150f.png">

(후)
<img width="868" alt="스크린샷 2023-02-07 오전 10 35 11" src="https://user-images.githubusercontent.com/82989054/217134077-d1fd1173-d763-41a7-8cef-65d6e8eb307a.png">
