### PR TITLE
[refactor] path 전송방식 변경에 따른 코드 리팩토링

### DIFF
--- a/src/components/LNB/SourceCodeTree.tsx
+++ b/src/components/LNB/SourceCodeTree.tsx
@@ -30,11 +30,8 @@ export const SourceCodeTree = () => {
 
     sourceCodeList.forEach((src) => {
       let node = resultJson;
-      const pathArray = src.srcPath.split('/');
+      const nodeArray = src.srcPath.split('/');
       const pathString = src.srcPath;
-      let nodeArray = pathArray.filter((nodePath, index) => {
-        return index > 0;
-      });
       nodeArray.forEach((nodePath, index) => {
         if (!node.children) {
           node.children = [];


### PR DESCRIPTION
서버에서 path 전송시에 맨앞의 / 를 빼고 전송해주도록 변경되어 불필요한 코드를 제거했습니다.