### PR TITLE
[bugfix][patch] SourceCodeTree 새로고침 시 바로 로딩

### DIFF
--- a/src/components/LNB/SourceCodeTree.tsx
+++ b/src/components/LNB/SourceCodeTree.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import FolderTree from 'react-folder-tree';
 import WorkspaceStore from '../../stores/workspaceStore';
-import { useObserver } from 'mobx-react';
+import { Observer } from 'mobx-react';
 import { sendMessage } from '../../utils/service-utils';
 import 'react-folder-tree/dist/style.css';
 
@@ -50,14 +50,16 @@ export const SourceCodeTree: React.FC = () => {
     return resultJson;
   };
 
-  const Treedata = pathToJson(WorkspaceStore.sourceCodeList);
-
-  return useObserver(() => (
-    <FolderTree
-      data={Treedata}
-      showCheckbox={false}
-      indentPixels={5}
-      onNameClick={onSourceCodeLinkClick}
-    />
-  ));
+  return (
+    <Observer>
+      {() => (
+        <FolderTree
+          data={pathToJson(WorkspaceStore.sourceCodeList)}
+          showCheckbox={false}
+          indentPixels={5}
+          onNameClick={onSourceCodeLinkClick}
+        />
+      )}
+    </Observer>
+  );
 };


### PR DESCRIPTION
[bugfix][patch] SourceCodeTree 새로고침 시 바로 로딩

WorkspaceStore 의 변화를 바로 반영하지 못하고 있었으므로 Ovserver 안쪽으로 pathToJson 과정을 수행하도록 변경함

useObserver 대신 Observer Component 쓰는것으로 권장하므로 변경