### PR TITLE
[feat] 디테일 페이지 구현

### DIFF
--- a/src/pages/Project/FileTreeView.tsx
+++ b/src/pages/Project/FileTreeView.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import FolderTree from 'react-folder-tree';
+import 'react-folder-tree/dist/style.css';
+function createTreeData(sourceCodeList) {
+  const treeData = [];
+
+  sourceCodeList.forEach((item) => {
+    const pathParts = item.srcPath.split('/');
+    let currentLevel = treeData;
+
+    pathParts.forEach((part, index) => {
+      const existingPath = currentLevel.find((level) => level.name === part);
+
+      if (existingPath) {
+        currentLevel = existingPath.children;
+      } else {
+        const newPart = {
+          name: part,
+          children: [],
+          isFile: index === pathParts.length - 1,
+          srcHistId: item.srcHistId,
+          createdTime: item.createdTime,
+          commitId: item.commitId,
+          srcId: item.srcId,
+        };
+
+        currentLevel.push(newPart);
+
+        if (!newPart.isFile) {
+          currentLevel = newPart.children;
+        }
+      }
+    });
+  });
+
+  return treeData;
+}
+function FileTreeView({ sourceCodeList }) {
+  const [treeData, setTreeData] = React.useState([]);
+
+  React.useEffect(() => {
+    setTreeData(createTreeData(sourceCodeList));
+  }, [sourceCodeList]);
+
+  return (
+    <div>
+      <FolderTree
+        data={treeData}
+        headerTemplate={({ item }) => (
+          <>
+            {item.isFile ? (
+              <i className="file-icon" />
+            ) : (
+              <i className="folder-icon" />
+            )}
+            <span>{item.name}</span>
+          </>
+        )}
+        onItemClick={({ item }) => {
+          console.log(1234, 'File clicked:', item);
+        }}
+      />
+    </div>
+  );
+}
+
+export default FileTreeView;

--- a/src/pages/Project/ProjectDetailPage.tsx
+++ b/src/pages/Project/ProjectDetailPage.tsx
@@ -1,22 +1,159 @@
 import * as React from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import Button from '@mui/material/Button';
-import { ProjectLNB } from '../../components/LNB/ProjectLNB';
+import WorkspaceStore from '../../stores/workspaceStore';
+import { Observer, observer } from 'mobx-react';
+import { Avatar } from '@mui/material';
+import { sendMessage } from '../../utils/service-utils';
+import { toJS } from 'mobx';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import FileTreeView from './FileTreeView';
 
 const ProjectDetailPage: React.FC = () => {
   const { projectName } = useParams();
 
+  React.useEffect(() => {
+    WorkspaceStore.updateCurrentProjectAction({ name: projectName });
+    sendMessage('reference', 'ListService', {
+      proj_name: projectName,
+    });
+  }, []);
+  React.useEffect(() => {
+    if (WorkspaceStore.currentCommit.commitId) {
+      sendMessage('commit', 'DetailService', {
+        commit_id: WorkspaceStore.currentCommit.commitId,
+      });
+    }
+  }, [WorkspaceStore.currentCommit.commitId]);
+
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
   return (
-    <div>
-      <ProjectLNB />
-      <div className="center-area">
-        {projectName} 프로젝트 상세페이지입니다.
-        <Link to={`/projects/${projectName}/editor`}>
-          <Button>Open Editor</Button>
-        </Link>
+    <div className="detail-body">
+      <div className="detail-main">
+        <div className="detail-in-flex">
+          <Avatar
+            sx={{
+              bgcolor: 'primary.main',
+              borderRadius: '20%',
+              top: '20px',
+              width: '80px',
+              height: '80px',
+              fontSize: '3.25rem',
+            }}
+          >
+            {projectName.charAt(0)}
+          </Avatar>
+          <div>
+            <h1>{projectName}</h1>
+            <p>Project ID: {WorkspaceStore.currentReference.projId}</p>
+          </div>
+        </div>
+        <div className="detail-in-flex">
+          <Button variant="outlined">HISTORY</Button>
+          <Button variant="contained" href={`#/projects/${projectName}/editor`}>
+            PX Editor
+          </Button>
+          <Button variant="contained">CI/CD</Button>
+        </div>
       </div>
+      <Observer>
+        {() => (
+          <>
+            <div className="detail-in-flex-under">
+              <Avatar
+                sx={{
+                  bgcolor: 'primary.main',
+                  borderRadius: '20%',
+                  top: '15px',
+                  width: '20px',
+                  height: '20px',
+                  fontSize: '0.25rem',
+                }}
+              >
+                {'IC'}
+              </Avatar>
+              <p>Add license</p>
+              <Avatar
+                sx={{
+                  bgcolor: 'primary.main',
+                  borderRadius: '20%',
+                  top: '15px',
+                  width: '20px',
+                  height: '20px',
+                  fontSize: '0.25rem',
+                }}
+              >
+                {'IC'}
+              </Avatar>
+              <p>{WorkspaceStore.commitList.length} Commits</p>
+              <Avatar
+                sx={{
+                  bgcolor: 'primary.main',
+                  borderRadius: '20%',
+                  top: '15px',
+                  width: '20px',
+                  height: '20px',
+                  fontSize: '0.25rem',
+                }}
+              >
+                {'IC'}
+              </Avatar>
+              <p>{WorkspaceStore.referenceList.length} Branches</p>
+              <Avatar
+                sx={{
+                  bgcolor: 'primary.main',
+                  borderRadius: '20%',
+                  top: '15px',
+                  width: '20px',
+                  height: '20px',
+                  fontSize: '0.25rem',
+                }}
+              >
+                {'IC'}
+              </Avatar>
+              <p>Tags</p>
+            </div>
+            <div className="detail-drop-down">
+              <Button
+                id="demo-customized-button"
+                aria-controls={open ? 'demo-customized-menu' : undefined}
+                aria-haspopup="true"
+                aria-expanded={open ? 'true' : undefined}
+                variant="contained"
+                disableElevation
+                onClick={handleClick}
+                endIcon={<KeyboardArrowDownIcon />}
+              >
+                main
+              </Button>
+              <Button
+                id="demo-customized-button"
+                aria-controls={open ? 'demo-customized-menu' : undefined}
+                aria-haspopup="true"
+                aria-expanded={open ? 'true' : undefined}
+                variant="contained"
+                disableElevation
+                onClick={handleClick}
+                endIcon={<KeyboardArrowDownIcon />}
+              >
+                Add file
+              </Button>
+            </div>
+            {/* {WorkspaceStore.sourceCodeList?.length && (
+              <div>
+                <FileTreeView sourceCodeList={WorkspaceStore.sourceCodeList} />
+              </div>
+            )} */}
+          </>
+        )}
+      </Observer>
     </div>
   );
 };
 
-export default ProjectDetailPage;
+export default observer(ProjectDetailPage);

--- a/src/style.css
+++ b/src/style.css
@@ -231,3 +231,31 @@ body,
   width: 0;
   height: 0;
 }
+.detail-body {
+  height: 100%;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+.detail-main {
+  height: 130;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 100px;
+}
+.detail-in-flex,
+.detail-in-flex-under {
+  display: flex;
+  gap: 12px;
+  z-index: 1;
+}
+.detail-in-flex-under {
+  padding: 20px;
+  border-bottom: 1px solid #ddd;
+}
+.detail-drop-down {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 20px;
+}


### PR DESCRIPTION
디테일 페이지 구현
<img width="1717" alt="스크린샷 2023-03-22 오전 11 40 19" src="https://user-images.githubusercontent.com/82989054/226788058-318cd3a4-e24d-4b38-a936-e37e1525b992.png">
밑에 파일 렌더링 부분은 아직 구현 안했습니다. 특정 라이브러리를 사용해야할 것 같습니다.