### PR TITLE
[feat] 탭파일 이름 대문자로 표시되는 오류 수정, 정상적인 프로젝트 들어갔다가 커밋이 없는 프로젝트 들어가면 readme파일 이전 프로젝트로 렌더링 되는 상황 수정, 첫페이지를 프로젝트 리스트 페이지로 수정

### DIFF
--- a/src/components/Editor/CustomTab.tsx
+++ b/src/components/Editor/CustomTab.tsx
@@ -24,6 +24,7 @@ export default function CustomTab(props: CustomTabProps) {
         onClick={() => {
           EditorContentsStore.updateVeiwIndex(index);
         }}
+        sx={{ textTransform: 'none' }}
       ></Tab>
       <Button
         onClick={() => {

--- a/src/components/GNB/GNB.tsx
+++ b/src/components/GNB/GNB.tsx
@@ -11,7 +11,7 @@ export const GNB = () => {
           <HomeIcon className="logo-icon" sx={{ color: '#FF7575' }} />
           <p className="logo-text">SuperPX</p>
         </Link>
-        <Link to="/projects">
+        <Link to="/">
           <p className="top-menu-text-left">Projects</p>
         </Link>
         {/* <Link to="/groups">

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,18 +39,14 @@ const router = createHashRouter([
     children: [
       {
         path: '',
-        element: <WelcomePage />,
-      },
-      {
-        path: 'projects',
         element: <ProjectPage />,
       },
       {
-        path: 'projects/:projectName/editor',
+        path: '/:projectName/editor',
         element: <EditorPage />,
       },
       {
-        path: 'projects/:projectName/*',
+        path: '/:projectName/*',
         element: <ProjectDetailPage />,
       },
       {

--- a/src/pages/Project/FileTreeView.tsx
+++ b/src/pages/Project/FileTreeView.tsx
@@ -63,7 +63,7 @@ const FileTreeView = ({ structure, currentPath, onClick }) => {
               button
               onClick={() =>
                 onClick(() => {
-                  window.location.hash = `#/projects/${projectName}/editor`;
+                  window.location.hash = `#/${projectName}/editor`;
                   sendMessage('source', 'DetailService', {
                     src_id: srcCodeId,
                     commit_id: WorkspaceStore.currentCommit.commitId,

--- a/src/pages/Project/ProjectPage.tsx
+++ b/src/pages/Project/ProjectPage.tsx
@@ -131,10 +131,10 @@ const ProjectPage: React.FC = () => {
                           });
                         }}
                       >
-                        <Link to={`/projects/${project.name}`}>
+                        <Link to={`/${project.name}`}>
                           <Box sx={{ p: 2 }}>
                             <Paper variant="outlined">
-                              <Link to={`/projects/${project.name}`}>
+                              <Link to={`/${project.name}`}>
                                 <Box sx={{ display: 'flex' }}>
                                   <Box sx={{ p: 2 }}>
                                     <Avatar sx={{ bgcolor: 'primary.main' }}>

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -12,10 +12,10 @@ export type Reference = {
 };
 
 export type Commit = {
-  commitId: number;
-  message: string;
-  preCommitId: number;
-  isCommit: boolean;
+  commitId?: number;
+  message?: string;
+  preCommitId?: number;
+  isCommit?: boolean;
 };
 
 export type SourceCode = {


### PR DESCRIPTION
탭파일 이름 대문자로 표시되는 오류 수정, 정상적인 프로젝트 들어갔다가 커밋이 없는 프로젝트 들어가면 readme파일 이전 프로젝트로 렌더링 되는 상황 수정, 첫페이지를 프로젝트 리스트 페이지로 수정하였습니다.
<img width="1646" alt="스크린샷 2023-03-28 오전 10 50 54" src="https://user-images.githubusercontent.com/82989054/228106127-a8229d30-f0ff-48ea-9f3f-4b2c8ad94627.png">
<img width="1015" alt="스크린샷 2023-03-28 오전 10 50 23" src="https://user-images.githubusercontent.com/82989054/228106132-444aa4d9-4524-4d11-80c3-e6957fd693a6.png">
<img width="892" alt="스크린샷 2023-03-28 오전 10 50 03" src="https://user-images.githubusercontent.com/82989054/228106134-e6b1481d-51df-4da0-9493-bb80c60ae81c.png">
