### PR TITLE
[feat] 기획에 맞게 프로젝트 GNB구현 

### DIFF
--- a/src/components/GNB/EditorGNB.tsx
+++ b/src/components/GNB/EditorGNB.tsx
@@ -11,23 +11,23 @@ import { ImportDirectoryDialog } from './ImportDirectoryDialog';
 export const EditorGNB = () => {
   const menus = [
     'file',
-    // 'edit',
-    // 'select',
-    // 'view',
-    // 'goto',
-    // 'debug',
-    // 'terminal',
-    // 'help',
+    'edit',
+    'select',
+    'view',
+    'goto',
+    'debug',
+    'terminal',
+    'help',
   ];
   const menusAction = {
     file: ['Import File', 'Import Directory'],
-    // edit: ['editAction1', 'editAction2'],
-    // select: ['selectAction1', 'selectAction2'],
-    // view: ['viewAction1', 'viewAction2'],
-    // goto: ['gotoAction1', 'gotoAction2'],
-    // debug: ['debugAction1', 'debugAction2'],
-    // terminal: ['terminalAction1', 'terminalAction2'],
-    // help: ['helpAction1', 'helpAction2'],
+    edit: ['editAction1', 'editAction2'],
+    select: ['selectAction1', 'selectAction2'],
+    view: ['viewAction1', 'viewAction2'],
+    goto: ['gotoAction1', 'gotoAction2'],
+    debug: ['debugAction1', 'debugAction2'],
+    terminal: ['terminalAction1', 'terminalAction2'],
+    help: ['helpAction1', 'helpAction2'],
   };
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [openMenu, setOpenMenu] = React.useState({});

--- a/src/components/GNB/GNB.tsx
+++ b/src/components/GNB/GNB.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import HomeIcon from '@mui/icons-material/Home';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import EditorContentsStore from '../../stores/editorContentsStore';
 import I18nButton from '../../utils/i18n/I18nButton';
 export const GNB = () => {
+  const { projectName } = useParams();
   return (
     <div className="gnb">
       <div className="logo">
@@ -18,17 +19,23 @@ export const GNB = () => {
           <p className="top-menu-text">Groups</p>
         </Link> */}
         <Link
-          to="/editor"
+          to={`/${projectName}/details`}
+          className={`top-menu-link ${!projectName ? 'disabled' : ''}`}
+        >
+          <p className="top-menu-text">PX Manager</p>
+        </Link>
+
+        <Link
+          to={`/${projectName}/editor`}
           onClick={() => {
             EditorContentsStore.updateEditorLnbInitState('scm');
           }}
+          className={`top-menu-link ${!projectName ? 'disabled' : ''}`}
         >
-          <p className="top-menu-text">Editor</p>
-        </Link>
-        <Link to="/about">
-          <p className="top-menu-text">About</p>
+          <p className="top-menu-text">PX Editor</p>
         </Link>
       </div>
+      {projectName && <div className="top-head-text">{projectName}</div>}
       <I18nButton />
     </div>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,11 +43,15 @@ const router = createHashRouter([
         element: <ProjectPage />,
       },
       {
-        path: 'projects/:projectName/editor',
+        path: '/:projectName',
+        element: <ProjectPage />,
+      },
+      {
+        path: '/:projectName/editor',
         element: <EditorPage />,
       },
       {
-        path: 'projects/:projectName/*',
+        path: '/:projectName/details/*',
         element: <ProjectDetailPage />,
       },
       {

--- a/src/pages/Project/FileTreeView.tsx
+++ b/src/pages/Project/FileTreeView.tsx
@@ -63,7 +63,7 @@ const FileTreeView = ({ structure, currentPath, onClick }) => {
               button
               onClick={() =>
                 onClick(() => {
-                  window.location.hash = `#/projects/${projectName}/editor`;
+                  window.location.hash = `#/${projectName}/editor`;
                   sendMessage('source', 'DetailService', {
                     src_id: srcCodeId,
                     commit_id: WorkspaceStore.currentCommit.commitId,

--- a/src/pages/Project/ProjectDetailPage.tsx
+++ b/src/pages/Project/ProjectDetailPage.tsx
@@ -27,9 +27,10 @@ const ProjectDetailPage: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [readme, setReadme] = React.useState('');
+
   React.useEffect(() => {
     const newPath = location.pathname
-      .replace(`/projects/${projectName}`, '')
+      .replace(`/${projectName}/details`, '')
       .split('/')
       .filter((part) => part.length > 0);
     setCurrentPath(newPath);
@@ -123,7 +124,7 @@ const ProjectDetailPage: React.FC = () => {
     setShowModal(true);
   };
   const handleCreateModal = () => {
-    window.location.hash = `#/projects/${projectName}/editor`;
+    window.location.hash = `#/${projectName}/editor`;
     EditorContentsStore.updateContentAction(inputValue, '');
     setShowModal(false);
     setInputValue('');
@@ -135,182 +136,213 @@ const ProjectDetailPage: React.FC = () => {
   const handleInputChange = (event) => {
     setInputValue(event.target.value);
   };
+  const menus = [
+    'Details',
+    'Issues',
+    'Merge Requests',
+    'CI/CD Report',
+    'Settings',
+    'PX Analysis',
+  ];
   return (
-    <div className="detail-body">
-      <div className="detail-main">
-        <div className="detail-in-flex">
-          <Avatar
-            sx={{
-              bgcolor: 'primary.main',
-              borderRadius: '20%',
-              top: '20px',
-              width: '80px',
-              height: '80px',
-              fontSize: '3.25rem',
-            }}
-          >
-            {projectName.charAt(0)}
-          </Avatar>
-          <div>
-            <h1>{projectName}</h1>
-            <p>Project ID: {WorkspaceStore.currentReference.projId}</p>
+    <div>
+      <div className="gnb-project-page">
+        {menus.map((menu) => {
+          return (
+            <span key={`menu-All`}>
+              <Button
+                className="gnb-menu-button"
+                id="basic-button"
+                aria-controls={open ? 'basic-menu' : undefined}
+                aria-haspopup="true"
+                aria-expanded={open ? 'true' : undefined}
+                // onClick={handleClick}
+                // value={menu}
+              >
+                {menu}
+              </Button>
+            </span>
+          );
+        })}
+      </div>
+      <div className="detail-body">
+        <div className="detail-main">
+          <div className="detail-in-flex">
+            <Avatar
+              sx={{
+                bgcolor: 'primary.main',
+                borderRadius: '20%',
+                top: '20px',
+                width: '80px',
+                height: '80px',
+                fontSize: '3.25rem',
+              }}
+            >
+              {projectName.charAt(0)}
+            </Avatar>
+            <div>
+              <h1>{projectName}</h1>
+              <p>Project ID: {WorkspaceStore.currentReference.projId}</p>
+            </div>
+          </div>
+          <div className="detail-in-flex">
+            <Button variant="outlined">HISTORY</Button>
+            <Button variant="contained" href={`#/${projectName}/editor`}>
+              PX Editor
+            </Button>
+            <Button variant="contained">CI/CD</Button>
           </div>
         </div>
-        <div className="detail-in-flex">
-          <Button variant="outlined">HISTORY</Button>
-          <Button variant="contained" href={`#/${projectName}/editor`}>
-            PX Editor
-          </Button>
-          <Button variant="contained">CI/CD</Button>
-        </div>
-      </div>
-      <Observer>
-        {() => (
-          <>
-            <div className="detail-in-flex-under">
-              <Avatar
-                sx={{
-                  bgcolor: 'primary.main',
-                  borderRadius: '20%',
-                  top: '15px',
-                  width: '20px',
-                  height: '20px',
-                  fontSize: '0.25rem',
-                }}
-              >
-                {'IC'}
-              </Avatar>
-              <p>Add license</p>
-              <Avatar
-                sx={{
-                  bgcolor: 'primary.main',
-                  borderRadius: '20%',
-                  top: '15px',
-                  width: '20px',
-                  height: '20px',
-                  fontSize: '0.25rem',
-                }}
-              >
-                {'IC'}
-              </Avatar>
-              <p>{WorkspaceStore.commitList.length} Commits</p>
-              <Avatar
-                sx={{
-                  bgcolor: 'primary.main',
-                  borderRadius: '20%',
-                  top: '15px',
-                  width: '20px',
-                  height: '20px',
-                  fontSize: '0.25rem',
-                }}
-              >
-                {'IC'}
-              </Avatar>
-              <p>
-                {
-                  WorkspaceStore.referenceList.filter((item) => item.type === 0)
-                    .length
-                }{' '}
-                Branches
-              </p>
-              <Avatar
-                sx={{
-                  bgcolor: 'primary.main',
-                  borderRadius: '20%',
-                  top: '15px',
-                  width: '20px',
-                  height: '20px',
-                  fontSize: '0.25rem',
-                }}
-              >
-                {'IC'}
-              </Avatar>
-              <p>
-                {
-                  WorkspaceStore.referenceList.filter((item) => item.type !== 0)
-                    .length
-                }{' '}
-                Tags
-              </p>
-            </div>
-            <div className="detail-drop-down">
-              <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
-                <InputLabel id="demo-select-small">reference</InputLabel>
-                <Select
-                  labelId="demo-select-small"
-                  id="demo-select-small"
-                  value={referenceId}
-                  label="reference"
-                  onChange={handleChange}
+        <Observer>
+          {() => (
+            <>
+              <div className="detail-in-flex-under">
+                <Avatar
+                  sx={{
+                    bgcolor: 'primary.main',
+                    borderRadius: '20%',
+                    top: '15px',
+                    width: '20px',
+                    height: '20px',
+                    fontSize: '0.25rem',
+                  }}
                 >
-                  {WorkspaceStore.referenceList.length &&
-                    WorkspaceStore.referenceList.map((workReference) => {
-                      return (
-                        <MenuItem value={workReference.refId}>
-                          <em>{workReference.name}</em>
-                        </MenuItem>
-                      );
-                    })}
-                </Select>
-              </FormControl>
-              <div>{currentPath.join('/')}</div>
-              <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
-                <InputLabel id="demo-select-small">action</InputLabel>
-                <Select
-                  labelId="demo-select-small"
-                  id="demo-select-small"
-                  value={action}
-                  label="action"
-                  onChange={handleActionChange}
+                  {'IC'}
+                </Avatar>
+                <p>Add license</p>
+                <Avatar
+                  sx={{
+                    bgcolor: 'primary.main',
+                    borderRadius: '20%',
+                    top: '15px',
+                    width: '20px',
+                    height: '20px',
+                    fontSize: '0.25rem',
+                  }}
                 >
-                  <MenuItem value={'Add file'} onClick={handleOpenModal}>
-                    Add file
-                  </MenuItem>
-                </Select>
-              </FormControl>
-            </div>
-            <Box>
-              {currentPath.length > 0 && (
-                <Box mb={1}>
-                  <Button onClick={handleBack}>{`../`}</Button>
-                </Box>
-              )}
+                  {'IC'}
+                </Avatar>
+                <p>{WorkspaceStore.commitList.length} Commits</p>
+                <Avatar
+                  sx={{
+                    bgcolor: 'primary.main',
+                    borderRadius: '20%',
+                    top: '15px',
+                    width: '20px',
+                    height: '20px',
+                    fontSize: '0.25rem',
+                  }}
+                >
+                  {'IC'}
+                </Avatar>
+                <p>
+                  {
+                    WorkspaceStore.referenceList.filter(
+                      (item) => item.type === 0,
+                    ).length
+                  }{' '}
+                  Branches
+                </p>
+                <Avatar
+                  sx={{
+                    bgcolor: 'primary.main',
+                    borderRadius: '20%',
+                    top: '15px',
+                    width: '20px',
+                    height: '20px',
+                    fontSize: '0.25rem',
+                  }}
+                >
+                  {'IC'}
+                </Avatar>
+                <p>
+                  {
+                    WorkspaceStore.referenceList.filter(
+                      (item) => item.type !== 0,
+                    ).length
+                  }{' '}
+                  Tags
+                </p>
+              </div>
+              <div className="detail-drop-down">
+                <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
+                  <InputLabel id="demo-select-small">reference</InputLabel>
+                  <Select
+                    labelId="demo-select-small"
+                    id="demo-select-small"
+                    value={referenceId}
+                    label="reference"
+                    onChange={handleChange}
+                  >
+                    {WorkspaceStore.referenceList.length &&
+                      WorkspaceStore.referenceList.map((workReference) => {
+                        return (
+                          <MenuItem value={workReference.refId}>
+                            <em>{workReference.name}</em>
+                          </MenuItem>
+                        );
+                      })}
+                  </Select>
+                </FormControl>
+                <div>{currentPath.join('/')}</div>
+                <FormControl sx={{ m: 1, minWidth: 120 }} size="small">
+                  <InputLabel id="demo-select-small">action</InputLabel>
+                  <Select
+                    labelId="demo-select-small"
+                    id="demo-select-small"
+                    value={action}
+                    label="action"
+                    onChange={handleActionChange}
+                  >
+                    <MenuItem value={'Add file'} onClick={handleOpenModal}>
+                      Add file
+                    </MenuItem>
+                  </Select>
+                </FormControl>
+              </div>
+              <Box>
+                {currentPath.length > 0 && (
+                  <Box mb={1}>
+                    <Button onClick={handleBack}>{`../`}</Button>
+                  </Box>
+                )}
 
-              <FileTreeView
-                structure={folderStructure}
-                currentPath={currentPath}
-                onClick={(path) => {
-                  setCurrentPath(path);
-                  navigate(`${path.join('/')}`);
-                }}
-              />
-            </Box>
-          </>
-        )}
-      </Observer>
-      <Dialog open={showModal} onClose={handleCancelModal}>
-        <DialogTitle> File name</DialogTitle>
-        <DialogContent>
-          <DialogContentText>Please enter a file name</DialogContentText>
-          <TextField
-            autoFocus
-            margin="dense"
-            id="name"
-            label="file name"
-            type="email"
-            fullWidth
-            variant="standard"
-            value={inputValue}
-            onChange={handleInputChange}
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCancelModal}>Cancel</Button>
-          <Button onClick={handleCreateModal}>Create</Button>
-        </DialogActions>
-      </Dialog>
-      <div className="markdown-container">
-        <ReactMarkdown>{readme}</ReactMarkdown>
+                <FileTreeView
+                  structure={folderStructure}
+                  currentPath={currentPath}
+                  onClick={(path) => {
+                    setCurrentPath(path);
+                    navigate(`${path.join('/')}`);
+                  }}
+                />
+              </Box>
+            </>
+          )}
+        </Observer>
+        <Dialog open={showModal} onClose={handleCancelModal}>
+          <DialogTitle> File name</DialogTitle>
+          <DialogContent>
+            <DialogContentText>Please enter a file name</DialogContentText>
+            <TextField
+              autoFocus
+              margin="dense"
+              id="name"
+              label="file name"
+              type="email"
+              fullWidth
+              variant="standard"
+              value={inputValue}
+              onChange={handleInputChange}
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleCancelModal}>Cancel</Button>
+            <Button onClick={handleCreateModal}>Create</Button>
+          </DialogActions>
+        </Dialog>
+        <div className="markdown-container">
+          <ReactMarkdown>{readme}</ReactMarkdown>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Project/ProjectPage.tsx
+++ b/src/pages/Project/ProjectPage.tsx
@@ -14,6 +14,7 @@ import Paper from '@mui/material/Paper';
 import Box from '@mui/material/Box';
 import Avatar from '@mui/material/Avatar';
 import {
+  Button,
   FormControl,
   InputAdornment,
   InputLabel,
@@ -70,6 +71,34 @@ const ProjectPage: React.FC = () => {
     <Observer>
       {() => (
         <div className="project-page-parent">
+          <div className="gnb-project-page">
+            <span key={`menu-All`}>
+              <Button
+                className="gnb-menu-button"
+                id="basic-button"
+                aria-controls={open ? 'basic-menu' : undefined}
+                aria-haspopup="true"
+                aria-expanded={open ? 'true' : undefined}
+                // onClick={handleClick}
+                // value={menu}
+              >
+                {'All'}
+              </Button>
+            </span>
+            <span key={`menu-Favorites`}>
+              <Button
+                className="gnb-menu-button"
+                id="basic-button"
+                aria-controls={open ? 'basic-menu' : undefined}
+                aria-haspopup="true"
+                aria-expanded={open ? 'true' : undefined}
+                // onClick={handleClick}
+                // value={menu}
+              >
+                {'Favorites'}
+              </Button>
+            </span>
+          </div>
           <div className="project-page">
             <div className="project-page-create">
               <h1>{t('PROJECTMAIN')}</h1>
@@ -139,7 +168,7 @@ const ProjectPage: React.FC = () => {
                         <Link to={`/${project.name}`}>
                           <Box sx={{ p: 2 }}>
                             <Paper variant="outlined">
-                              <Link to={`/projects/${project.name}`}>
+                              <Link to={`/${project.name}/details`}>
                                 <Box sx={{ display: 'flex' }}>
                                   <Box sx={{ p: 2 }}>
                                     <Avatar sx={{ bgcolor: 'primary.main' }}>

--- a/src/style.css
+++ b/src/style.css
@@ -8,7 +8,11 @@ body,
 .title {
   height: 50px;
 }
-
+.top-menu-link.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 @media only screen and (max-height: 600px) {
   .center-container {
     height: 50%;
@@ -93,6 +97,14 @@ body,
   display: flex;
   justify-content: space-between;
 }
+.gnb-project-page {
+  background: #070e26;
+  overflow: auto;
+  width: 100%;
+  height: 72;
+  padding: 0px 15px 0px 0px;
+  display: flex;
+}
 .logo {
   display: flex;
   height: 36px;
@@ -130,16 +142,25 @@ body,
   line-height: 13px;
   color: #ffffff;
 }
-
+.top-head-text {
+  height: 15px;
+  padding-right: 200px;
+  position: relative;
+  font-size: 15px;
+  padding-top: 15px;
+  line-height: 13px;
+  color: #ffffff;
+  font-weight: bold;
+}
 .gnb-menu-button {
-  padding: 10px 8px !important;
-  width: 76px;
-  height: 36px;
+  padding: 10px 28px !important;
+  height: 30px;
   background: #070e26;
   color: #ffffff !important;
   font-weight: 700 !important;
   font-size: 13px !important;
   line-height: 14px !important;
+  text-transform: none !important;
 }
 
 .commit-link {
@@ -210,6 +231,7 @@ body,
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-direction: column;
 }
 
 .source-code-tree {


### PR DESCRIPTION
메뉴 구성 변경
프로젝트 진입 전 (생성 이후에도) PX Manager, PX Editor 메뉴 비활성화
프로젝트를 선택할시 탑 메뉴 중앙에 표시
프로젝트 페이지, 메니저 페이지, 에디터 페이지 일시적 메뉴 구성
라우팅 리팩토링
<img width="1394" alt="스크린샷 2023-03-30 오전 9 53 07" src="https://user-images.githubusercontent.com/82989054/228700578-9fafe2b8-66bf-480e-9646-d39a2b3939cd.png">
<img width="1376" alt="스크린샷 2023-03-30 오전 9 52 50" src="https://user-images.githubusercontent.com/82989054/228700584-6443c4c3-0ab1-42b3-aa85-cd301c422d9f.png">
<img width="1403" alt="스크린샷 2023-03-30 오전 9 52 38" src="https://user-images.githubusercontent.com/82989054/228700588-b5d105e0-75b9-4aad-bbe8-5d6b29a98210.png">


