### PR TITLE
[feat] 하단 스크롤 숨김

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -70,6 +70,7 @@ body,
   position: sticky;
   height: calc(100% - 36px);
   overflow-y: auto;
+  overflow-x: hidden;
 }
 .lnb-btn {
   z-index: 3;


### PR DESCRIPTION
상하 스크롤이 생기면 그만큼 가려져서 하단의 좌우 스크롤이 생기는 문제가 발생

overflow-x: hidden 으로 하여 안보이도록 함