### PR TITLE
[feat] table component 분기로 처리하던 방식 내부 컴포넌트 생성 CI/CD Report 대략적으로 구성 및 menus 정상라우팅되게 수정

### DIFF
--- a/src/pages/CICD/CICDListPage.tsx
+++ b/src/pages/CICD/CICDListPage.tsx
@@ -1,5 +1,100 @@
+import { Avatar, Box, Button } from '@mui/material';
+import { Observer, observer } from 'mobx-react';
 import React from 'react';
+import { Link, useParams } from 'react-router-dom';
+import WorkspaceStore from '../../stores/workspaceStore';
+import { sendMessage } from '../../utils/service-utils';
+import TablePage from '../../utils/TablePage';
+import { CICD } from '../../utils/types';
 
-export default function CICDListPage() {
-  return <div>CICDListPage</div>;
-}
+const InnerComponent = (item: CICD) => (
+  <Link to={`/projects/${item.projName}/details`}>
+    <Box sx={{ display: 'flex' }}>
+      <Box sx={{ p: 2 }}>
+        <Avatar
+          sx={{
+            bgcolor: 'primary.main',
+            borderRadius: '20%',
+          }}
+        >
+          {String(item.cicdId)?.charAt(0)}
+        </Avatar>
+      </Box>
+      <Box sx={{ p: 2 }}>
+        <div className="item-name">
+          <b>{item.cicdId}</b>
+        </div>
+        <div className="item-name">{item.createdTime}</div>
+      </Box>
+    </Box>
+  </Link>
+);
+
+const CICDListPage = () => {
+  const { projectName } = useParams();
+  const [cicdList, setCicdList] = React.useState([]);
+  const menus = [
+    { name: 'Details', to: `/projects/${projectName}/details` },
+    { name: 'CI/CD Report', to: `/projects/${projectName}/CICDList` },
+    // 'Issues',
+    // 'Merge Requests',
+    // 'Settings',
+    // 'PX Analysis',
+  ];
+  React.useEffect(() => {
+    sendMessage('project', 'DetailService', {
+      proj_name: projectName,
+    });
+  }, []);
+  React.useEffect(() => {
+    WorkspaceStore.currentProject?.projId &&
+      sendMessage(
+        'service',
+        'GetHistoryList',
+        {
+          proj_id: WorkspaceStore.currentProject.projId,
+        },
+        'super-px/com.tmax.buildanddeploy',
+      );
+  }, [WorkspaceStore.currentProject]);
+  React.useEffect(() => {
+    setCicdList(WorkspaceStore.CICDList);
+  }, [WorkspaceStore.CICDList]);
+
+  return (
+    <div className="project-page-parent">
+      <div className="gnb-project-page">
+        {menus.map((menu) => {
+          return (
+            <span key={`menu-All-${menu.name}`}>
+              <Button
+                className="gnb-menu-button"
+                id="basic-button"
+                component={Link}
+                to={menu.to}
+              >
+                {menu.name}
+              </Button>
+            </span>
+          );
+        })}
+      </div>
+      <Observer>
+        {() => (
+          <>
+            <TablePage
+              itemList={cicdList}
+              setItemList={setCicdList}
+              InnerComponent={InnerComponent}
+              rawProjectList={WorkspaceStore.CICDList}
+              mainName={'CI/CD Report'}
+              cellClickFuntion={() => {}}
+              type="CICD"
+            />
+          </>
+        )}
+      </Observer>
+    </div>
+  );
+};
+export default observer(CICDListPage);

--- a/src/pages/Project/CommitHistory.tsx
+++ b/src/pages/Project/CommitHistory.tsx
@@ -1,10 +1,32 @@
 import * as React from 'react';
 import { Observer, observer } from 'mobx-react';
 import WorkspaceStore from '../../stores/workspaceStore';
-import { Button } from '@mui/material';
+import { Avatar, Box, Button } from '@mui/material';
 import { sendMessage } from '../../utils/service-utils';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import TablePage from '../../utils/TablePage';
+import { Commit } from '../../utils/types';
+
+const InnerComponent = (item: Commit) => (
+  <Box sx={{ display: 'flex' }}>
+    <Box sx={{ p: 2 }}>
+      <Avatar
+        sx={{
+          bgcolor: 'primary.main',
+          borderRadius: '20%',
+        }}
+      >
+        {item.message?.charAt(0)}
+      </Avatar>
+    </Box>
+    <Box sx={{ p: 2 }}>
+      <div className="item-name">
+        <b>{item.message}</b>
+      </div>
+      <div className="item-name">{item.createdTime}</div>
+    </Box>
+  </Box>
+);
 
 const CommitHistory: React.FC = () => {
   const { projectName } = useParams();
@@ -32,10 +54,10 @@ const CommitHistory: React.FC = () => {
     };
   }, []);
   const menus = [
-    'Details',
+    { name: 'Details', to: `/projects/${projectName}/details` },
+    { name: 'CI/CD Report', to: `/projects/${projectName}/CICDList` },
     // 'Issues',
     // 'Merge Requests',
-    'CI/CD Report',
     // 'Settings',
     // 'PX Analysis',
   ];
@@ -45,8 +67,13 @@ const CommitHistory: React.FC = () => {
         {menus.map((menu) => {
           return (
             <span key={`menu-All`}>
-              <Button className="gnb-menu-button" id="basic-button">
-                {menu}
+              <Button
+                className="gnb-menu-button"
+                id="basic-button"
+                component={Link}
+                to={menu.to}
+              >
+                {menu.name}
               </Button>
             </span>
           );
@@ -58,6 +85,7 @@ const CommitHistory: React.FC = () => {
             <TablePage
               itemList={commitList}
               setItemList={setCommitList}
+              InnerComponent={InnerComponent}
               rawProjectList={WorkspaceStore.commitList}
               mainName={'Commit List'}
               cellClickFuntion={() => {}}

--- a/src/pages/Project/ProjectDetailPage.tsx
+++ b/src/pages/Project/ProjectDetailPage.tsx
@@ -53,10 +53,10 @@ const ProjectDetailPage: React.FC = () => {
   const [masterModal, setMasterModal] = React.useState(false);
   const [targetIp, setTargetIp] = React.useState('');
   const menus = [
-    'Details',
+    { name: 'Details', to: `/projects/${projectName}/details` },
+    { name: 'CI/CD Report', to: `/projects/${projectName}/CICDList` },
     // 'Issues',
     // 'Merge Requests',
-    'CI/CD Report',
     // 'Settings',
     // 'PX Analysis',
   ];
@@ -191,9 +191,14 @@ const ProjectDetailPage: React.FC = () => {
       <div className="gnb-project-page">
         {menus.map((menu) => {
           return (
-            <span key={`menu-All`}>
-              <Button className="gnb-menu-button" id="basic-button">
-                {menu}
+            <span key={`menu-All-${menu.name}`}>
+              <Button
+                className="gnb-menu-button"
+                id="basic-button"
+                component={Link}
+                to={menu.to}
+              >
+                {menu.name}
               </Button>
             </span>
           );

--- a/src/pages/Project/ProjectPage.tsx
+++ b/src/pages/Project/ProjectPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { observer, Observer } from 'mobx-react';
 import WorkspaceStore from '../../stores/workspaceStore';
 import { sendMessage } from '../../utils/service-utils';
-import { Button } from '@mui/material';
+import { Avatar, Box, Button } from '@mui/material';
 import loadingStore from '../../stores/loadingStore';
 import LoadingScreen from '../../components/Loading/LoadingScreen';
 import TablePage from '../../utils/TablePage';
@@ -21,7 +21,28 @@ const projectClickFuntion = (project: Project) => {
     proj_name: project.name,
   });
 };
-
+const InnerComponent = (item: Project) => (
+  <Link to={`/projects/${item.name}/details`}>
+    <Box sx={{ display: 'flex' }}>
+      <Box sx={{ p: 2 }}>
+        <Avatar
+          sx={{
+            bgcolor: 'primary.main',
+            borderRadius: '20%',
+          }}
+        >
+          {item.name?.charAt(0)}
+        </Avatar>
+      </Box>
+      <Box sx={{ p: 2 }}>
+        <div className="item-name">
+          <b>{item.name}</b>
+        </div>
+        <div className="item-name">{item.name}</div>
+      </Box>
+    </Box>
+  </Link>
+);
 const ProjectPage: React.FC = () => {
   const [projectList, setProjectList] = React.useState([]);
 
@@ -54,6 +75,7 @@ const ProjectPage: React.FC = () => {
           <TablePage
             itemList={projectList}
             setItemList={setProjectList}
+            InnerComponent={InnerComponent}
             rawProjectList={WorkspaceStore.projectList}
             mainName={t('PROJECTMAIN')}
             TableButton={<TableButton />}

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -59,7 +59,7 @@ const WorkspaceStore = observable({
   },
 
   updateCurrentProjectAction(project: Project) {
-    this.currentProject = project;
+    this.currentProject = { ...project };
   },
 
   updateReferenceListAction(referenceList: Reference[]) {
@@ -135,7 +135,7 @@ const WorkspaceStore = observable({
     this.CICDList = [...CICDList];
   },
   updateCICDAction(CICD: CICD) {
-    this.currentCICD = {...CICD};
+    this.currentCICD = { ...CICD };
   },
 });
 

--- a/src/utils/TablePage.tsx
+++ b/src/utils/TablePage.tsx
@@ -1,6 +1,4 @@
 import {
-  Avatar,
-  Box,
   FormControl,
   InputAdornment,
   InputLabel,
@@ -15,7 +13,6 @@ import {
   TextField,
 } from '@mui/material';
 import React, { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
 import SearchIcon from '@mui/icons-material/Search';
 import styled from '@emotion/styled';
 import Table from '@mui/material/Table';
@@ -24,11 +21,12 @@ import TablePagination from '@mui/material/TablePagination';
 interface TablePageProps {
   itemList: any[];
   setItemList: (list: any[]) => void;
+  InnerComponent: any;
   mainName: string;
   TableButton?: ReactElement;
   rawProjectList: any[];
   cellClickFuntion: any;
-  type: 'project' | 'commit';
+  type: 'project' | 'commit' | 'CICD';
 }
 
 const StyledTableCell = styled(TableCell)({
@@ -40,6 +38,7 @@ const TablePage = (props: TablePageProps) => {
   const {
     itemList,
     setItemList,
+    InnerComponent,
     mainName,
     TableButton,
     rawProjectList,
@@ -142,16 +141,6 @@ const TablePage = (props: TablePageProps) => {
             {itemList
               .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
               .map((item) => {
-                const linkTo =
-                  type === 'project'
-                    ? `/projects/${item.name}/details`
-                    : `/projects`;
-                const itemName =
-                  type === 'project'
-                    ? item.name
-                    : type === 'commit'
-                    ? item.message
-                    : 'No Name';
                 return (
                   <TableRow key={`project-${item.projId}`}>
                     <StyledTableCell
@@ -159,39 +148,7 @@ const TablePage = (props: TablePageProps) => {
                         cellClickFuntion(item);
                       }}
                     >
-                      <Link to={linkTo}>
-                        <Box sx={{ p: 2 }}>
-                          <Paper variant="outlined">
-                            <Link to={linkTo}>
-                              <Box sx={{ display: 'flex' }}>
-                                <Box sx={{ p: 2 }}>
-                                  <Avatar
-                                    sx={{
-                                      bgcolor: 'primary.main',
-                                      borderRadius: '20%',
-                                    }}
-                                  >
-                                    {itemName?.charAt(0)}
-                                  </Avatar>
-                                </Box>
-                                <Box sx={{ p: 2 }}>
-                                  <div className="item-name">
-                                    <b>{itemName}</b>
-                                  </div>
-                                  {type === 'project' && (
-                                    <div className="item-name">{itemName}</div>
-                                  )}
-                                  {type === 'commit' && (
-                                    <div className="item-name">
-                                      {item.createdTime}
-                                    </div>
-                                  )}
-                                </Box>
-                              </Box>
-                            </Link>
-                          </Paper>
-                        </Box>
-                      </Link>
+                      <Paper variant="outlined">{InnerComponent(item)}</Paper>
                     </StyledTableCell>
                   </TableRow>
                 );

--- a/src/utils/service-utils.ts
+++ b/src/utils/service-utils.ts
@@ -57,7 +57,9 @@ const projectGenerateService = (data) => {
 const projectListService = (data) => {
   WorkspaceStore.updateProjectListAction(data);
 };
-const projectDetailService = (data) => {};
+const projectDetailService = (data) => {
+  WorkspaceStore.updateCurrentProjectAction(data);
+};
 const projectDeleteService = (data) => {};
 
 const referenceInsertService = (data) => {
@@ -133,6 +135,9 @@ const serviceCicdSA = (data) => {
     ? setAlert(`success`, data.message, 'success')
     : setAlert(`error`, data.message, 'error');
 };
+const serviceGetHistoryList = (data) => {
+  WorkspaceStore.updateCICDListAction(data);
+};
 export const services = {
   ProjectInsertService: projectInsertService,
   ProjectListService: projectListService,
@@ -148,4 +153,5 @@ export const services = {
   ProjectGenerateService: projectGenerateService,
   CicdMW: serviceCicdMW,
   CicdSA: serviceCicdSA,
+  GetHistoryList: serviceGetHistoryList,
 };


### PR DESCRIPTION
<img width="1702" alt="스크린샷 2023-04-11 오전 9 41 17" src="https://user-images.githubusercontent.com/82989054/231026439-de8afcc4-2a62-4e1e-933a-08dafd10e6fe.png">
서버에서 보내주는 자료와 기획의 자료가 일치하는 데이터가 없어서 일단 서버에서 보내주는 자료로 최대한 구성하였습니다.