### PR TITLE
[feat][Bugfix] cicd id 정렬, 오타수정, commitHistory 페이지 새로고침했을때 데이터 없어지는 현상 수정 추가 치명적인 url 수정,blank project 생성하여 commit 을 보면 이전에 열었던 프로젝트의 커 밋 리스트보여지는 현상 수정

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -60,7 +60,7 @@ const router = createBrowserRouter([
         element: <EditorPage />,
       },
       {
-        path: '/projects/:projectName/commitHistory',
+        path: '/projects/:projectName/commitHistory/:reference',
         element: <CommitHistory />,
       },
       {

--- a/src/pages/CICD/CICDListPage.tsx
+++ b/src/pages/CICD/CICDListPage.tsx
@@ -86,7 +86,7 @@ const TableHeader = () => {
     <StyledTableRow>
       <StyledTableCell className="cicd-left-align">CICD Id</StyledTableCell>
       <StyledTableCell className="cicd-left-align">
-        Refence Name
+        Reference Name
       </StyledTableCell>
       <StyledTableCell className="cicd-left-align">Mode</StyledTableCell>
       <StyledTableCell className="cicd-left-align">
@@ -101,10 +101,6 @@ const CICDListPage = () => {
   const menus = [
     { name: 'Details', to: `/projects/${projectName}/details` },
     { name: 'CI/CD Report', to: `/projects/${projectName}/CICDList` },
-    // 'Issues',
-    // 'Merge Requests',
-    // 'Settings',
-    // 'PX Analysis',
   ];
   const [referenceId, setReferenceId] = React.useState('');
   const [ciCdSelect, setCiCdSelect] = React.useState(false);
@@ -152,8 +148,13 @@ const CICDListPage = () => {
         proj_name: projectName,
       });
   }, [WorkspaceStore.currentProject]);
+
   React.useEffect(() => {
-    setCicdList(WorkspaceStore.CICDList);
+    setCicdList(
+      WorkspaceStore.CICDList.sort((a, b) => {
+        return String(a.cicdId).localeCompare(String(b.cicdId));
+      }),
+    );
   }, [WorkspaceStore.CICDList]);
 
   return (

--- a/src/pages/Project/CommitHistory.tsx
+++ b/src/pages/Project/CommitHistory.tsx
@@ -29,8 +29,18 @@ const InnerComponent = (item: Commit) => (
 );
 
 const CommitHistory: React.FC = () => {
-  const { projectName } = useParams();
+  const { projectName, reference } = useParams();
   const [commitList, setCommitList] = React.useState([]);
+  React.useEffect(() => {
+    setCommitList(
+      WorkspaceStore.commitList.sort((a, b) => {
+        const dateA = new Date(a.createdTime);
+        const dateB = new Date(b.createdTime);
+        return dateB.getTime() - dateA.getTime();
+      }),
+    );
+  }, []);
+
   React.useEffect(() => {
     setCommitList(
       WorkspaceStore.commitList.sort((a, b) => {
@@ -41,14 +51,14 @@ const CommitHistory: React.FC = () => {
     );
   }, [WorkspaceStore.commitList]);
   React.useEffect(() => {
-    const timer = setInterval(
-      () =>
-        sendMessage('commit', 'ListService', {
-          proj_name: projectName,
-          ref_name: WorkspaceStore.currentReference.name,
-        }),
-      20000,
-    );
+    const sendRequest = () => {
+      sendMessage('commit', 'ListService', {
+        proj_name: projectName,
+        ref_name: reference.replace(/-dot-/g, '.').replace(/-slash-/g, '/'),
+      });
+    };
+    sendRequest();
+    const timer = setInterval(sendRequest, 20000);
     return () => {
       clearInterval(timer);
     };

--- a/src/pages/Project/ProjectDetailPage.tsx
+++ b/src/pages/Project/ProjectDetailPage.tsx
@@ -168,10 +168,9 @@ const ProjectDetailPage: React.FC = () => {
           });
           EditorContentsStore.initContentAction();
           navigate(
-            `/projects/${projectName}/details/${reference.name.replace(
-              /[/.]/g,
-              '-',
-            )}`,
+            `/projects/${projectName}/details/${reference.name
+              .replace(/\./g, '-dot-')
+              .replace(/\//g, '-slash-')}`,
           );
         }
       });
@@ -226,7 +225,7 @@ const ProjectDetailPage: React.FC = () => {
             </div>
           </div>
           <div className="detail-in-flex">
-            <Link to={`/projects/${projectName}/commitHistory`}>
+            <Link to={`/projects/${projectName}/commitHistory/${reference}`}>
               <Button variant="outlined">HISTORY</Button>
             </Link>
             <Link to={`/projects/${projectName}/editor`}>

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -34,11 +34,16 @@ const WorkspaceStore = observable({
         return;
       }
       path === 'ProjectGenerateService' && loadingStore.setLoading(false);
-      service
-        ? data
-          ? service(data)
-          : setAlert(`No ${path} Data.`, message, 'error')
-        : setAlert(message, `No Service ${path}.`, 'error');
+      if (service) {
+        if (data) {
+          service(data);
+        } else {
+          setAlert(`No ${path} Data.`, message, 'error');
+          path === 'CommitListService' && this.updateCommitListAction([]);
+        }
+      } else {
+        setAlert(message, `No Service ${path}.`, 'error');
+      }
     };
   },
   resetWsUrlAction() {


### PR DESCRIPTION
cicd id 정렬, Reference Name 밀림, 오타수정, commitHistory 페이지 새로고침했을때 데이터 없어지는 현상 수정 추가 치명적인 url 수정,blank project 생성하여 commit 을 보면 이전에 열었던 프로젝트의 커 밋 리스트보여지는 현상 수정
<img width="1100" alt="스크린샷 2023-04-12 오전 8 31 06" src="https://user-images.githubusercontent.com/82989054/231310478-d4ad4bd6-7ea6-4902-bdce-26cc5584f7f4.png">
