### PR TITLE
[feat][patch][IMS 302282] create from template page에서 group명, jdk 값 입력 방식 수정 및 프로젝트네임 중복 검사

### DIFF
--- a/src/pages/Project/CreateBlank.tsx
+++ b/src/pages/Project/CreateBlank.tsx
@@ -22,17 +22,20 @@ import WorkspaceStore from '../../stores/workspaceStore';
 interface DuplicationButtonProps {
   btnType: string;
   setDuplicateState: (type: string) => void;
+  projectName: string;
 }
+
 export const DuplicationButton: React.FC<DuplicationButtonProps> = ({
   btnType,
   setDuplicateState,
+  projectName,
 }) => {
   switch (btnType) {
     case 'ready':
       return (
         <Button
           onClick={() => {
-            setDuplicateState('loading');
+            projectName && setDuplicateState('loading');
             sendMessage('project', 'ListService', {});
           }}
           color="secondary"
@@ -69,6 +72,7 @@ export default function CreateBlank() {
   };
   const handleProjectNameChange = (event) => {
     setProjectName(event.target.value);
+    setDuplicateState('ready');
   };
   React.useEffect(() => {
     if (!projectName) {
@@ -142,6 +146,7 @@ export default function CreateBlank() {
         <DuplicationButton
           btnType={duplicateState}
           setDuplicateState={setDuplicateState}
+          projectName={projectName}
         />
       </div>
 

--- a/src/pages/Project/CreateTemplate.tsx
+++ b/src/pages/Project/CreateTemplate.tsx
@@ -11,15 +11,18 @@ import { useTranslation } from 'react-i18next';
 import { sendMessage } from '../../utils/service-utils';
 import { useNavigate } from 'react-router-dom';
 import loadingStore from '../../stores/loadingStore';
+import { DuplicationButton } from './CreateBlank';
+import WorkspaceStore from '../../stores/workspaceStore';
 
 export default function CreateTemplate() {
   const { t } = useTranslation();
   // const [buildSystem, setBuildSystem] = React.useState('');
   const [group, setGroup] = React.useState('');
   const [version, setVersion] = React.useState('');
-  const [jdk, setJdk] = React.useState('');
+  const [jdk, setJdk] = React.useState('1.8');
   const [isImport, setIsImport] = React.useState(true);
   const [projectName, setProjectName] = React.useState('');
+  const [duplicateState, setDuplicateState] = React.useState('ready');
   const [invalidProjectNameHelp, setinValidProjectNameHelp] =
     React.useState('');
   const handleProjectNameChange = (event) => {
@@ -35,7 +38,14 @@ export default function CreateTemplate() {
     }
   }, [projectName]);
   const navigate = useNavigate();
-
+  React.useEffect(() => {
+    if (WorkspaceStore.projectList.length && duplicateState === 'loading') {
+      const isDuplicate = WorkspaceStore.projectList.some(
+        (pj) => pj.name === projectName,
+      );
+      setDuplicateState(isDuplicate ? 'error' : 'success');
+    }
+  }, [WorkspaceStore.projectList, duplicateState]);
   return (
     <div className="project-page-parent">
       <div className="create-page-blank-head">
@@ -79,6 +89,10 @@ export default function CreateTemplate() {
           value={projectName}
           onChange={handleProjectNameChange}
         />
+        <DuplicationButton
+          btnType={duplicateState}
+          setDuplicateState={setDuplicateState}
+        />
       </div>
 
       <div className="create-page-blank">
@@ -104,11 +118,11 @@ export default function CreateTemplate() {
         <TextField
           helperText={'Enter Build Group'}
           id={'demo-helper-text-aligned'}
-          label={'Enter Build Group'}
           value={group}
           onChange={(event) => {
             setGroup(event.target.value);
           }}
+          placeholder="com.tmax"
         />
       </div>
       <div className="create-page-blank">
@@ -131,15 +145,18 @@ export default function CreateTemplate() {
           <h3>JDK</h3>
           <h5>(optional)</h5>
         </div>
-        <TextField
-          helperText={'Enter JDK'}
-          id={'demo-helper-text-aligned'}
-          label={'Enter JDK'}
-          value={jdk}
-          onChange={(event) => {
-            setJdk(event.target.value);
-          }}
-        />
+        <FormControl>
+          <RadioGroup
+            aria-labelledby="demo-radio-buttons-group-label"
+            value={jdk}
+            onChange={(event) => {
+              setJdk(event.target.value);
+            }}
+          >
+            <FormControlLabel value={'1.8'} control={<Radio />} label="1.8" />
+            <FormControlLabel value={'11'} control={<Radio />} label="11" />
+          </RadioGroup>
+        </FormControl>
       </div>
       <div className="create-page-blank">
         <div>

--- a/src/pages/Project/CreateTemplate.tsx
+++ b/src/pages/Project/CreateTemplate.tsx
@@ -27,6 +27,7 @@ export default function CreateTemplate() {
     React.useState('');
   const handleProjectNameChange = (event) => {
     setProjectName(event.target.value);
+    setDuplicateState('ready');
   };
   React.useEffect(() => {
     if (!projectName) {
@@ -92,6 +93,7 @@ export default function CreateTemplate() {
         <DuplicationButton
           btnType={duplicateState}
           setDuplicateState={setDuplicateState}
+          projectName={projectName}
         />
       </div>
 


### PR DESCRIPTION
[feat][patch][IMS 302282] create from template page에서 group명, jdk 값 입력 방식 수정
[프로젝트네임 중복 검사]
<img width="473" alt="스크린샷 2023-04-20 오전 8 16 53" src="https://user-images.githubusercontent.com/82989054/233221360-ee4ee32f-07ac-4bfb-b57e-4fd2059d9cbc.png">
<img width="481" alt="스크린샷 2023-04-20 오전 8 16 39" src="https://user-images.githubusercontent.com/82989054/233221363-3b09103e-158f-4094-b4ae-6c638e6ae658.png">
<img width="830" alt="스크린샷 2023-04-20 오전 8 16 17" src="https://user-images.githubusercontent.com/82989054/233221366-d414dba7-75e9-4685-aef3-5c8052eddddc.png">
<img width="1089" alt="스크린샷 2023-04-19 오후 5 02 49" src="https://user-images.githubusercontent.com/82989054/233221383-fc4019b9-e8b0-4974-b2b7-8d684bb520e0.png">
<img width="577" alt="스크린샷 2023-04-20 오전 8 17 10" src="https://user-images.githubusercontent.com/82989054/233221460-eecb8dc6-cbd2-49bb-8fa9-3f4eca96bad3.png">


